### PR TITLE
Implement Alpha-Beta Pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Ampersand"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "monster_chess",
  "monster_ugi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Ampersand"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,7 +44,14 @@ impl<const T: usize> EngineBehavior<T> for AmpersandEngine<T> {
 
             search_info.nodes = 0;
 
-            let new_score = negamax(board, &mut search_info, depth, 0);
+            let new_score = negamax(
+                board, 
+                &mut search_info, 
+                depth, 
+                0, 
+                -1_000_000,
+                1_000_000
+            );
             if search_info.ended {
                 break;
             }
@@ -81,7 +88,7 @@ impl<const T: usize> EngineBehavior<T> for AmpersandEngine<T> {
 
     fn get_engine_info(&mut self) -> EngineInfo {
         EngineInfo {
-            name: "Ampersand v0.0.1",
+            name: "Ampersand v0.0.2",
             author: "Corman"
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -21,7 +21,9 @@ pub fn negamax<const T: usize>(
     board: &mut Board<T>, 
     search_info: &mut SearchInfo,
     depth: u32, 
-    ply: u32
+    ply: u32,
+    mut alpha: i32,
+    beta: i32
 ) -> i32 {
     if depth == 0 { 
         let eval = evaluate(board);
@@ -64,12 +66,21 @@ pub fn negamax<const T: usize>(
 
         search_info.nodes += 1;
         let undo = board.make_move(&action);
-        let score = -negamax(board, search_info, depth - 1, ply + 1);
+        let score = -negamax(board, search_info, depth - 1, ply + 1, -beta, -alpha);
+        board.undo_move(undo);
+
         if score > max {
             best_move = Some(action);
             max = score;
         }
-        board.undo_move(undo);
+
+        if max > alpha {
+            alpha = max;
+        }
+
+        if alpha >= beta {
+            break; // Beta cutoff
+        }
     }
 
     if ply == 0 && !search_info.ended {


### PR DESCRIPTION
Alpha-Beta Pruning is a form of pruning [which doesn't change the result of the base Negamax search](https://www.chessprogramming.org/Alpha-Beta). If a good move has already been found, other moves only need to be refuted as worse than that move to have their trees pruned.

```
Score of Ampersand v0.0.2 vs Ampersand v0.0.1: 44 - 5 - 8  [0.842] 57
...      Ampersand v0.0.2 playing White: 26 - 1 - 2  [0.931] 29
...      Ampersand v0.0.2 playing Black: 18 - 4 - 6  [0.750] 28
...      White vs Black: 30 - 19 - 8  [0.596] 57
Elo difference: 290.8 +/- 115.4, LOS: 100.0 %, DrawRatio: 14.0 %
SPRT: llr 2.97 (102.9%), lbound -2.25, ubound 2.89 - H1 was accepted
```

Above is a SPRT test of the implementation of this change, where `v0.0.2` is the implementation of Alpha Beta. Clearly, it is a remarkable improvement. There is no reason not to merge this.