### PR TITLE
Implement MVV-LVA Ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-perf.data
+perf.data*
 sprt.bash
 stockfish-ubuntu-x86-64-modern
 UHO_4060_v2.epd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "Ampersand"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
+ "lazy_static",
  "monster_chess",
  "monster_ugi",
  "rand",
@@ -58,6 +59,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "Ampersand"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.4.0"
 monster_chess = "0.0.24"
 monster_ugi = "0.0.19"
 rand = "0.8.5"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -88,7 +88,7 @@ impl<const T: usize> EngineBehavior<T> for AmpersandEngine<T> {
 
     fn get_engine_info(&mut self) -> EngineInfo {
         EngineInfo {
-            name: "Ampersand v0.0.2",
+            name: "Ampersand v0.0.3",
             author: "Corman"
         }
     }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,9 +1,21 @@
-use std::os::unix::thread;
+use std::{os::unix::thread, collections::HashMap};
 
-use monster_chess::{board::Board, games::chess::pieces::{PAWN, BISHOP, KNIGHT, QUEEN, ROOK}, bitboard::BitBoard};
+use lazy_static::lazy_static;
+use monster_chess::{board::Board, games::chess::pieces::{PAWN, BISHOP, KNIGHT, QUEEN, ROOK, KING}, bitboard::BitBoard};
 use rand::{random, thread_rng, Rng, rngs::StdRng, SeedableRng};
 
 use crate::search::SearchInfo;
+
+lazy_static! {
+    pub static ref MATERIAL: HashMap<usize, i32> = [
+        (PAWN, 100),
+        (KNIGHT, 325),
+        (BISHOP, 350),
+        (ROOK, 500),
+        (QUEEN, 900),
+        (KING, 10_000)
+    ].into();
+}
 
 struct Teams<const T: usize> {
     team: BitBoard<T>, 
@@ -42,9 +54,9 @@ pub fn evaluate<const T: usize>(
 
     let rand = thread_rng().gen_range(-20..20);
 
-    teams.material_difference(pawns, 100) +
-    teams.material_difference(knights, 325) +
-    teams.material_difference(bishops, 350) +
-    teams.material_difference(rooks, 500) +
-    teams.material_difference(queens, 900) + rand
+    teams.material_difference(pawns, MATERIAL[&PAWN]) +
+    teams.material_difference(knights, MATERIAL[&KNIGHT]) +
+    teams.material_difference(bishops, MATERIAL[&BISHOP]) +
+    teams.material_difference(rooks, MATERIAL[&ROOK]) +
+    teams.material_difference(queens, MATERIAL[&QUEEN]) + rand
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
-use monster_chess::{board::{Board, game::{NORMAL_MODE, GameResults}, actions::Move, tests::get_time_ms}, games::chess::{pieces::KING, ATTACKS_MODE}};
+use monster_chess::{board::{Board, game::{NORMAL_MODE, GameResults}, actions::{Move, SimpleMove}, tests::get_time_ms}, games::chess::{pieces::{KING, PAWN, QUEEN, KNIGHT}, ATTACKS_MODE}, bitboard::BitBoard};
 use rand::rngs::StdRng;
 
-use crate::evaluate::evaluate;
+use crate::evaluate::{evaluate, MATERIAL};
 
 #[derive(Debug, Clone, Copy)]
 pub enum SearchEnd {
@@ -15,6 +15,38 @@ pub struct SearchInfo {
     pub nodes: u64,
     pub search_end: SearchEnd,  
     pub ended: bool
+}
+
+pub fn move_score<const T: usize>(
+    board: &mut Board<T>, 
+    action: &Move
+) -> i32 {
+    match action {
+        SimpleMove::Pass => {
+            0
+        },
+        SimpleMove::Action(action) => {
+            let opposing_team = board.state.teams[board.get_next_team(board.state.moving_team) as usize];
+    
+            let dest = BitBoard::from_lsb(action.to);
+            if !(dest & opposing_team).is_set() {
+                return 0;
+            }
+
+            let mut captured_piece_type: usize = PAWN;
+            for piece_type in PAWN..KING {
+                if (board.state.pieces[piece_type] & dest).is_set() {
+                    captured_piece_type = piece_type;
+                    break;
+                }
+            }
+
+            let moved = MATERIAL[&(action.piece_type as usize)];
+            let captured = MATERIAL[&captured_piece_type];            
+
+            1000 + (captured - moved)
+        }
+    }
 }
 
 pub fn negamax<const T: usize>(
@@ -62,8 +94,16 @@ pub fn negamax<const T: usize>(
         }
     }
 
-    for action in moves {
+    let mut scored_moves = moves.into_iter().map(|action| {
+        let score = move_score(board, &action);
+        (action, score)
+    }).collect::<Vec<_>>();
 
+    scored_moves.sort_by(|&a, &b| {
+        b.1.cmp(&a.1)
+    });
+
+    for (action, _score) in scored_moves {
         search_info.nodes += 1;
         let undo = board.make_move(&action);
         let score = -negamax(board, search_info, depth - 1, ply + 1, -beta, -alpha);


### PR DESCRIPTION
For Alpha Beta Pruning to be optimal, better moves must be prioritized in the move list before other moves. This allows for the beta cutoff to happen much earlier then otherwise, allowing for quick refutations. MVV-LVA is a simple way to order captures by:

1. Prioritizing captures over quiets
2. Prioritizing captures based on the captured piece's material minus the moved piece's material

```
Score of Ampersand v0.0.3 vs Ampersand v0.0.2: 50 - 15 - 28  [0.688] 93
...      Ampersand v0.0.3 playing White: 28 - 6 - 14  [0.729] 48
...      Ampersand v0.0.3 playing Black: 22 - 9 - 14  [0.644] 45
...      White vs Black: 37 - 28 - 28  [0.548] 93
Elo difference: 137.5 +/- 62.3, LOS: 100.0 %, DrawRatio: 30.1 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```

The SPRT test above confirms that this move ordering significantly improves Ampersand's performance, despite the performance hit to nodes per second.