### PR TITLE
Optimize move generation & Add quiescence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Ampersand"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "lazy_static",
  "monster_chess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Ampersand"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "lazy_static",
  "monster_chess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Ampersand"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Ampersand"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -88,7 +88,7 @@ impl<const T: usize> EngineBehavior<T> for AmpersandEngine<T> {
 
     fn get_engine_info(&mut self) -> EngineInfo {
         EngineInfo {
-            name: "Ampersand v0.0.3",
+            name: "Ampersand v0.0.4",
             author: "Corman"
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -88,7 +88,7 @@ impl<const T: usize> EngineBehavior<T> for AmpersandEngine<T> {
 
     fn get_engine_info(&mut self) -> EngineInfo {
         EngineInfo {
-            name: "Ampersand v0.0.4",
+            name: "Ampersand v0.0.5",
             author: "Corman"
         }
     }


### PR DESCRIPTION
This is a simple change that optimizes move generation, by checking moves for legality as they're iterated over in the negamax loop.

```
Score of Ampersand v0.0.4 vs Ampersand v0.0.3: 145 - 68 - 72  [0.635] 285
...      Ampersand v0.0.4 playing White: 77 - 25 - 41  [0.682] 143
...      Ampersand v0.0.4 playing Black: 68 - 43 - 31  [0.588] 142
...      White vs Black: 120 - 93 - 72  [0.547] 285
Elo difference: 96.3 +/- 35.8, LOS: 100.0 %, DrawRatio: 25.3 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
Finished match
```